### PR TITLE
update project and copyrigth info in NOTICE file

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,5 +1,5 @@
-All content in this repository on Github.
+iox-modbus-mqtt
 
-Copyright (c) 2019 Flo Pachinger
+Copyright (c) 2019 Cisco Systems, Inc. and/or its affiliates
 
 This project includes software developed at Cisco Systems, Inc. and/or its affiliates.


### PR DESCRIPTION
For contributions from Cisco employees, the Copyright owner should be Cisco.